### PR TITLE
Check Vercel main branch deploy

### DIFF
--- a/.github/workflows/deploy-vercel-main.yml
+++ b/.github/workflows/deploy-vercel-main.yml
@@ -1,0 +1,41 @@
+name: Deploy main to Vercel (prebuilt)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with Vercel (generate prebuilt output)
+        run: npx --yes vercel build --prod
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy prebuilt to Vercel Production
+        run: npx --yes vercel deploy --prebuilt --prod --yes
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+

--- a/VERCEL_CLI_GUIDE.md
+++ b/VERCEL_CLI_GUIDE.md
@@ -92,6 +92,23 @@ vercel
 
 ---
 
+## **🤖 CI/CD: Prebuild e deploy di `main` su Vercel**
+
+Per pubblicare automaticamente il branch `main` come deploy precompilato (prebuilt):
+
+1. Imposta i segreti nel repository GitHub (Settings → Secrets and variables → Actions):
+   - `VERCEL_TOKEN`
+   - `VERCEL_ORG_ID`
+   - `VERCEL_PROJECT_ID`
+
+2. Il workflow `.github/workflows/deploy-vercel-main.yml` esegue:
+   - `vercel build --prod` per creare l'artifact precompilato
+   - `vercel deploy --prebuilt --prod --yes` per pubblicarlo in produzione
+
+Assicurati che `vercel.json` sia allineato alla tua build (es. `outputDirectory: "docs"`) e che il progetto su Vercel punti a questo repository.
+
+---
+
 ## **✅ Vantaggi Vercel CLI**
 
 - ✅ **No Git** richiesto


### PR DESCRIPTION
Add a GitHub Actions workflow to enable prebuilt deployments of the `main` branch to Vercel and document the setup.

The existing setup did not have a mechanism for Vercel to automatically deploy prebuilt artifacts from the `main` branch, making it impossible to verify its status. This PR introduces a CI/CD pipeline to address this by building and deploying prebuilt artifacts directly from GitHub Actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-3923f287-05ad-440e-9301-43f09008c1c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3923f287-05ad-440e-9301-43f09008c1c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

