### PR TITLE
Fix onboarding stuck at step two

### DIFF
--- a/src/components/onboarding-steps/DepartmentsStep.jsx
+++ b/src/components/onboarding-steps/DepartmentsStep.jsx
@@ -80,6 +80,22 @@ const DepartmentsStep = ({
   // RIMOSSO: useEffect che causava loop infinito
   // updateFormData viene chiamato solo quando necessario (add/edit/delete)
 
+  // Sincronizza i reparti selezionati nel formData globale quando cambiano
+  useEffect(() => {
+    setFormData(prev => ({
+      ...prev,
+      departments: {
+        ...prev.departments,
+        list: departments,
+        enabledCount: departments.filter(d => d.enabled).length
+      }
+    }));
+    // Se lo step era stato confermato, torna allo stato non confermato dopo modifiche
+    if (isStepConfirmed(currentStep)) {
+      markStepAsUnconfirmed(currentStep);
+    }
+  }, [departments]);
+
   // Rimuoviamo la funzione handleConfirmData - non più necessaria
 
   return (


### PR DESCRIPTION
Update `DepartmentsStep.jsx` to synchronize department changes with `formData`.

This fixes a bug where step 2 of onboarding was blocked because the `formData` was not updated when departments were changed, causing the step validator to incorrectly report no enabled departments.

---
<a href="https://cursor.com/background-agent?bcId=bc-a449970b-0e06-4bbb-a7c2-7b0d2bc57a00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a449970b-0e06-4bbb-a7c2-7b0d2bc57a00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

