### PR TITLE
Fix onboarding next button bug

### DIFF
--- a/src/components/onboarding-steps/DepartmentsStep.jsx
+++ b/src/components/onboarding-steps/DepartmentsStep.jsx
@@ -80,6 +80,17 @@ const DepartmentsStep = ({
   // RIMOSSO: useEffect che causava loop infinito
   // updateFormData viene chiamato solo quando necessario (add/edit/delete)
 
+  // Aggiorna il formData globale quando cambia la lista dei reparti
+  useEffect(() => {
+    setFormData(prev => ({
+      ...prev,
+      departments: {
+        list: departments,
+        enabledCount: departments.filter(d => d.enabled).length
+      }
+    }));
+  }, [departments, setFormData]);
+
   // Rimuoviamo la funzione handleConfirmData - non più necessaria
 
   return (


### PR DESCRIPTION
Persist local department changes to `formData` in `DepartmentsStep.jsx` to fix the disabled 'Avanti' button on onboarding step 2.

The onboarding wizard's step 2 validation relies on `formData.departments.list` and `enabledCount`. Previously, `DepartmentsStep` did not update `formData` when local department changes occurred, causing the 'Avanti' button to remain disabled even when requirements were met.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ac44237-d6cf-47e4-bf43-19c943c47621">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ac44237-d6cf-47e4-bf43-19c943c47621">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

